### PR TITLE
fix : failing connected tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jdk:
 
 # Emulator Management: Create, Start and Wait
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --skin WXGA720
   - emulator -avd test -no-audio -no-window &
   - ./wait_for_emulator
   - adb shell input keyevent 82 &


### PR DESCRIPTION
The avd created is vary small for any UI tests to be ran on it and hence causes the connected tests to fail in travis.
This PR aims to fix the issue.
Source : [https://github.com/travis-ci/docs-travis-ci-com/pull/466](https://github.com/travis-ci/docs-travis-ci-com/pull/466)
